### PR TITLE
Basic entity extractor service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+entity-extractor
+_vendor

--- a/Gomfile
+++ b/Gomfile
@@ -1,0 +1,2 @@
+gom 'github.com/alext/tablecloth', :commit => 'b373a9a'
+gom 'github.com/cloudflare/ahocorasick', :commit => '1ce46e42b741851faf33c1bf283eeae6676f70a8'

--- a/Gomfile
+++ b/Gomfile
@@ -1,2 +1,3 @@
 gom 'github.com/alext/tablecloth', :commit => 'b373a9a'
 gom 'github.com/cloudflare/ahocorasick', :commit => '1ce46e42b741851faf33c1bf283eeae6676f70a8'
+gom 'github.com/stretchr/testify/assert'

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2013 Government Digital Service
+Copyright (c) 2015 Government Digital Service
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: build run test clean
+
+BINARY := entity-extractor
+BUILDFILES := config.go extractor.go extractor_api.go main.go
+IMPORT_BASE := github.com/alphagov
+IMPORT_PATH := $(IMPORT_BASE)/entity-extractor
+
+build: _vendor
+	gom build -o $(BINARY) $(BUILDFILES)
+
+run: _vendor
+	gom run $(BUILDFILES)
+
+test: _vendor build
+	gom test -v
+
+clean:
+	rm -f $(BINARY)
+
+_vendor: Gomfile _vendor/src/$(IMPORT_PATH)
+	gom install
+	touch _vendor
+
+_vendor/src/$(IMPORT_PATH):
+	rm -f _vendor/src/$(IMPORT_PATH)
+	mkdir -p _vendor/src/$(IMPORT_BASE)
+	ln -s $(CURDIR) _vendor/src/$(IMPORT_PATH)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,110 @@
 # Entity Extractor
 
 Service for extracting named entities from text
+
+## Overview/purpose
+
+An entity is any well known real world *thing* such as a person, place,
+organisation, policy etc.
+
+A 'named entity' is any such thing which has a well known name, for example
+'Government Digital Service'. Many entities will be known by multiple names,
+for example Government Digital Service is also known as 'GDS'.
+
+Therefore each entity my be identified by a set of terms, and is ascribed an
+identifier.
+
+```
+{"terms":["Government digital service","GDS"],"id":"1"}
+```
+
+We anticipate building a corpus of known named entities collated from various
+sources.
+
+Once we have a well defined corpus of known named entities, we can use that
+during document indexing and search.
+
+The entity-extractor service will be used during both of these operations.
+
+When indexing the document, the entity-extractor will be used to find out
+which entities are contained in the document. The list of entity ids will be
+stored alongside the document.
+
+When searching, the entity-extractor will be used to determine which entities
+were mentioned in the search query. These will then be added to the search
+command to boost query results which mention the same entity.
+
+## Installation
+
+The `entity-extractor` service can built using make:
+
+```
+$ cd entity-extractor
+$ make
+```
+
+this uses the [`gom`](https://github.com/mattn/gom) dependency manager to
+fetch required packages, before building the tool itself.
+
+You can see the list of dependencies in the [Gomfile](Gomfile).
+
+## Running tests
+
+The tests can be run with `make test` which will also fetch dependencies and
+compile the package if needed:
+
+```
+$ make test
+...
+gom test -v
+=== RUN TestParseEntityFromJson
+--- PASS: TestParseEntityFromJson (0.00s)
+=== RUN TestLoadEntities
+2015/01/15 12:04:41 Loading entities from /Users/davidheath/alphagov/entity-extractor/data/entities.jsonl
+2015/01/15 12:04:41 Loaded 4 terms
+--- PASS: TestLoadEntities (0.00s)
+=== RUN TestExtract
+2015/01/15 12:04:41 Loading entities from /Users/davidheath/alphagov/entity-extractor/data/entities.jsonl
+2015/01/15 12:04:41 Loaded 4 terms
+--- PASS: TestExtract (0.00s)
+PASS
+ok    _/Users/davidheath/alphagov/entity-extractor  0.012s
+```
+
+## Running the service
+
+The service is configured using the following environment variables:
+
+  * `EXTRACTOR_EXTRACT_ADDR` - address which the server listens on. Default `:3096`
+  * `EXTRACTOR_ENTITIES_PATH` - path to the [json lines](http://jsonlines.org/) file containing known entities to be loaded when the server starts up. Default `data/entities.jsonl`
+  * `EXTRACTOR_LOG_PATH` - file on which to write logging output. Default `STDERR`
+
+To start the service, set any environment variables you may need and then just run
+`entity-extractor`:
+
+```
+$ ./entity-extractor
+2015/01/15 11:39:17 logging JSON to STDERR
+2015/01/15 11:39:17 using GOMAXPROCS value of 2
+2015/01/15 11:39:17 Loading entities from data/entities.jsonl
+2015/01/15 11:39:17 Loaded 4 terms
+2015/01/15 11:39:17 listening for requests on :3096
+```
+
+## Using the service
+
+The entity-extractor service offers a single API endpoint `POST /extract`.
+This accepts a document and returns the entity IDs of entities found in that
+document.
+
+```
+$ curl -XPOST -d'document mentioning GDS' localhost:3096/extract
+["1"]
+
+$ curl -XPOST -d'document mentioning GDS and MoJ' localhost:3096/extract
+["1","2"]
+
+$ curl -XPOST -d'document mentioning neither' localhost:3096/extract
+[]
+```
+

--- a/config.go
+++ b/config.go
@@ -15,7 +15,7 @@ type Config struct {
 func NewConfig() *Config {
 	cfg := new(Config)
 
-	cfg.extractAddress = getenvDefault("EXTRACTOR_EXTRACT_ADDR", ":9999")
+	cfg.extractAddress = getenvDefault("EXTRACTOR_EXTRACT_ADDR", ":3096")
 	cfg.entitiesPath = getenvDefault("EXTRACTOR_ENTITIES_PATH", "/var/apps/entity-extractor/data/entities.jsonl")
 	cfg.logPath = getenvDefault("EXTRACTOR_LOG_PATH", "STDERR")
 
@@ -30,7 +30,7 @@ func usage() {
 	helpstring := `
 The following environment variables and defaults are available:
 
-EXTRACTOR_EXTRACT_ADDR=:9999  Address on which to serve extraction requests
+EXTRACTOR_EXTRACT_ADDR=:3096  Address on which to serve extraction requests
 EXTRACTOR_ENTITIES_PATH=/var/apps/entity-extractor/data/entities.jsonl
                               Path of file holding entities in jsonlines format
 EXTRACTOR_ERROR_LOG=STDERR    File to log errors to (in JSON format)

--- a/config.go
+++ b/config.go
@@ -16,7 +16,7 @@ func NewConfig() *Config {
 	cfg := new(Config)
 
 	cfg.extractAddress = getenvDefault("EXTRACTOR_EXTRACT_ADDR", ":3096")
-	cfg.entitiesPath = getenvDefault("EXTRACTOR_ENTITIES_PATH", "/var/apps/entity-extractor/data/entities.jsonl")
+	cfg.entitiesPath = getenvDefault("EXTRACTOR_ENTITIES_PATH", "data/entities.jsonl")
 	cfg.logPath = getenvDefault("EXTRACTOR_LOG_PATH", "STDERR")
 
 	flag.Usage = usage

--- a/config.go
+++ b/config.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+type Config struct {
+	extractAddress string
+	entitiesPath   string
+	logPath        string
+}
+
+func NewConfig() *Config {
+	cfg := new(Config)
+
+	cfg.extractAddress = getenvDefault("EXTRACTOR_EXTRACT_ADDR", ":9999")
+	cfg.entitiesPath = getenvDefault("EXTRACTOR_ENTITIES_PATH", "/var/apps/entity-extractor/data/entities.jsonl")
+	cfg.logPath = getenvDefault("EXTRACTOR_LOG_PATH", "STDERR")
+
+	flag.Usage = usage
+	flag.Parse()
+
+	return cfg
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Usage: %s\n", os.Args[0])
+	helpstring := `
+The following environment variables and defaults are available:
+
+EXTRACTOR_EXTRACT_ADDR=:9999  Address on which to serve extraction requests
+EXTRACTOR_ENTITIES_PATH=/var/apps/entity-extractor/data/entities.jsonl
+                              Path of file holding entities in jsonlines format
+EXTRACTOR_ERROR_LOG=STDERR    File to log errors to (in JSON format)
+`
+	fmt.Fprintf(os.Stderr, helpstring)
+	os.Exit(2)
+}
+
+func getenvDefault(key string, defaultVal string) string {
+	val := os.Getenv(key)
+	if val == "" {
+		val = defaultVal
+	}
+	return val
+}

--- a/data/entities.jsonl
+++ b/data/entities.jsonl
@@ -1,0 +1,2 @@
+{"terms":["Government digital service","GDS"],"id":"1"}
+{"terms":["Ministry of Justice","MoJ"],"id":"2"}

--- a/extractor.go
+++ b/extractor.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"github.com/cloudflare/ahocorasick"
+	"os"
+)
+
+// An entity (which has an ID and several representative strings)
+type Entity struct {
+	id          string
+	termOffsets []uint
+}
+
+type Entities struct {
+	terms              []string
+	termOffsetToEntity []*Entity
+}
+
+type Extractor struct {
+	cfg      *Config
+	entities Entities
+	matcher  *ahocorasick.Matcher
+}
+
+func NewExtractor(cfg *Config) *Extractor {
+	return &Extractor{cfg: cfg}
+}
+
+func (extr *Extractor) LoadEntities() error {
+	return extr.loadEntitiesFromFile(extr.cfg.entitiesPath)
+}
+
+type ParsedEntity struct {
+	terms []string
+	id    string
+}
+
+func EntityFromJSON(raw string) (*ParsedEntity, error) {
+	var parsed ParsedEntity
+	err := json.Unmarshal([]byte(raw), &parsed)
+	return &parsed, err
+}
+
+func (extr *Extractor) loadEntitiesFromFile(path string) error {
+	logInfo("Loading entities from", path)
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	var entities Entities
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		_, err := EntityFromJSON(line)
+		if err != nil {
+			return err
+		}
+
+		// FIXME - need to parse the JSON entity here,
+		// extract each representation as a term and add
+		// to the terms array.  Also need to build a map
+		// from offset in the terms array to a list of
+		// entity IDs.  Also need to handle multiple
+		// instances of each entity.
+		entities.terms = append(entities.terms, line)
+		//entities.termOffsetToEntity = append(entities.termOffsetToEntity, entity)
+	}
+
+	//extr.terms = terms
+	//extr.matcher = ahocorasick.NewStringMatcher(terms)
+	//logInfo("Loaded", len(extr.terms), "entities")
+
+	extr.entities = entities
+	return nil
+}

--- a/extractor.go
+++ b/extractor.go
@@ -70,10 +70,19 @@ func (extr *Extractor) loadEntitiesFromFile(path string) error {
 		entities.addEntity(entity)
 	}
 
-	//extr.terms = terms
-	//extr.matcher = ahocorasick.NewStringMatcher(terms)
-	//logInfo("Loaded", len(extr.terms), "entities")
+	extr.matcher = ahocorasick.NewStringMatcher(entities.terms)
+	logInfo("Loaded", len(entities.terms), "terms")
 
 	extr.entities = entities
 	return nil
+}
+
+func (extr *Extractor) Extract(text string) []string {
+	matchIndexes := extr.matcher.Match([]byte(text))
+	matchingTermIds := make([]string, 0, 1000)
+	for _, termIndex := range matchIndexes {
+		matchingTermIds = append(matchingTermIds, extr.entities.termOffsetToEntity[termIndex].id)
+	}
+
+	return matchingTermIds
 }

--- a/extractor.go
+++ b/extractor.go
@@ -38,7 +38,7 @@ type ParsedEntity struct {
 }
 
 func EntityFromJSON(raw string) (*ParsedEntity, error) {
-	var parsed ParsedEntity
+	parsed := ParsedEntity{make([]string, 0), ""}
 	err := json.Unmarshal([]byte(raw), &parsed)
 	return &parsed, err
 }

--- a/extractor.go
+++ b/extractor.go
@@ -69,6 +69,9 @@ func (extr *Extractor) loadEntitiesFromFile(path string) error {
 		}
 		entities.addEntity(entity)
 	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
 
 	extr.matcher = ahocorasick.NewStringMatcher(entities.terms)
 	logInfo("Loaded", len(entities.terms), "terms")

--- a/extractor_api.go
+++ b/extractor_api.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/http"
 )
 
@@ -17,7 +18,20 @@ func NewExtractorAPI(extractor *Extractor) http.Handler {
 		w.Write([]byte("OK"))
 	})
 
-	// FIXME - add endpoint to perform extraction
+	mux.HandleFunc("/extract", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			w.Header().Set("Allow", "POST")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		postBody := make([]byte, 10000)
+		r.Body.Read(postBody)
+		matchedTermIds := extractor.Extract(string(postBody))
+		marshalled, _ := json.Marshal(matchedTermIds)
+
+		w.Write(marshalled)
+	})
 
 	return mux
 }

--- a/extractor_api.go
+++ b/extractor_api.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"net/http"
+)
+
+func NewExtractorAPI(extractor *Extractor) http.Handler {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			w.Header().Set("Allow", "GET")
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Write([]byte("OK"))
+	})
+
+	// FIXME - add endpoint to perform extraction
+
+	return mux
+}

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -74,3 +74,18 @@ func TestLoadEntities(t *testing.T) {
 		assert.Equal(t, expectedId, extractor.entities.termOffsetToEntity[i].id)
 	}
 }
+
+func TestExtract(t *testing.T) {
+	config := Config{
+		extractAddress: ":9999",
+		entitiesPath:   fixturePath("entities.jsonl"),
+		logPath:        "STDERR",
+	}
+
+	extractor := NewExtractor(&config)
+	extractor.LoadEntities()
+
+	document := "This document mentions GDS but it doesn't mention the Ministry of J..."
+	matchedTermIds := extractor.Extract(document)
+	assert.Equal(t, []string{"1"}, matchedTermIds)
+}

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -45,14 +45,17 @@ func fixturePath(fixtureFile string) string {
 	return path.Join(path.Dir(filename), "data", fixtureFile)
 }
 
-func TestLoadEntities(t *testing.T) {
-	config := Config{
-		extractAddress: ":9999",
+func exampleConfig() *Config {
+	return &Config{
+		extractAddress: ":3096",
 		entitiesPath:   fixturePath("entities.jsonl"),
 		logPath:        "STDERR",
 	}
+}
 
-	extractor := NewExtractor(&config)
+func TestLoadEntities(t *testing.T) {
+	config := exampleConfig()
+	extractor := NewExtractor(config)
 	extractor.LoadEntities()
 
 	expectedTerms := [...]string{
@@ -76,13 +79,8 @@ func TestLoadEntities(t *testing.T) {
 }
 
 func TestExtract(t *testing.T) {
-	config := Config{
-		extractAddress: ":9999",
-		entitiesPath:   fixturePath("entities.jsonl"),
-		logPath:        "STDERR",
-	}
-
-	extractor := NewExtractor(&config)
+	config := exampleConfig()
+	extractor := NewExtractor(config)
 	extractor.LoadEntities()
 
 	document := "This document mentions GDS but it doesn't mention the Ministry of J..."

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"github.com/stretchr/testify/assert"
+	"path"
+	"runtime"
 	"testing"
 )
 
@@ -35,5 +37,40 @@ func TestParseEntityFromJson(t *testing.T) {
 		assert.Equal(t, example.expectedError, err, fmt.Sprint("unexpected error in example ", i))
 		assert.Equal(t, example.expectedTerms, actual.Terms, fmt.Sprint("terms differ in example ", i))
 		assert.Equal(t, example.expectedId, actual.Id, fmt.Sprint("ids differ in example ", i))
+	}
+}
+
+func fixturePath(fixtureFile string) string {
+	_, filename, _, _ := runtime.Caller(1)
+	return path.Join(path.Dir(filename), "data", fixtureFile)
+}
+
+func TestLoadEntities(t *testing.T) {
+	config := Config{
+		extractAddress: ":9999",
+		entitiesPath:   fixturePath("entities.jsonl"),
+		logPath:        "STDERR",
+	}
+
+	extractor := NewExtractor(&config)
+	extractor.LoadEntities()
+
+	expectedTerms := [...]string{
+		"Government digital service",
+		"GDS",
+		"Ministry of Justice",
+		"MoJ",
+	}
+	for i, expectedTerm := range expectedTerms {
+		assert.Equal(t, expectedTerm, extractor.entities.terms[i])
+	}
+	expectedIds := [...]string{
+		"1",
+		"1",
+		"2",
+		"2",
+	}
+	for i, expectedId := range expectedIds {
+		assert.Equal(t, expectedId, extractor.entities.termOffsetToEntity[i].id)
 	}
 }

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -1,53 +1,40 @@
 package main
 
 import (
-	"strings"
+	// "strings"
+	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 type ParseExample struct {
-	raw   string
-	terms []string
-	id    string
-	err   error
+	raw           string
+	expectedTerms []string
+	expectedId    string
+	expectedError error
 }
 
 var parseExamples = []ParseExample{
 	{
 		"{}",
-		[]string{},
+		make([]string, 0),
 		"",
 		nil,
 	},
-	{
-		`{"terms":["Government digital service","GDS"],"id":"1"}`,
-		[]string{"Government digital service", "GDS"},
-		"1",
-		nil,
-	},
-	{
-		`{"`,
-		[]string{},
-		"",
-		nil,
-	},
+	// {
+	// 	`{"terms":["Government digital service","GDS"],"id":"1"}`,
+	// 	[]string{"Government digital service", "GDS"},
+	// 	"1",
+	// 	nil,
+	// },
 }
 
 func TestParseEntityFromJson(t *testing.T) {
 	for i, example := range parseExamples {
-		entity, err := EntityFromJSON(example.raw)
+		actual, err := EntityFromJSON(example.raw)
 
-		if err != example.err {
-			t.Error("unexpected error in example", i, "error:", err, "expected:", example.err)
-		}
-
-		joinedTerms := strings.Join(entity.terms, ",")
-		joinedExpectedTerms := strings.Join(example.terms, ",")
-		if joinedTerms != joinedExpectedTerms {
-			t.Error("in example", i, "entity.terms != example.terms", joinedTerms, joinedExpectedTerms)
-		}
-		if entity.id != example.id {
-			t.Error("in example", i, "entity.id != example.id")
-		}
+		assert.Equal(t, example.expectedError, err, fmt.Sprint("unexpected error in example ", i))
+		assert.Equal(t, example.expectedTerms, actual.terms, fmt.Sprint("terms differ in example ", i))
+		assert.Equal(t, example.expectedId, actual.id, fmt.Sprint("ids differ in example ", i))
 	}
 }

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -78,12 +78,37 @@ func TestLoadEntities(t *testing.T) {
 	}
 }
 
+type ExtractionExample struct {
+	comment         string
+	document        string
+	expectedTermIds []string
+}
+
+var extractionExamples = []ExtractionExample{
+	{
+		"a document matching a single word term",
+		"This document mentions GDS but it doesn't mention the Ministry of J...",
+		[]string{"1"},
+	},
+	{
+		"a document matching a multi-word term",
+		"Government digital service",
+		[]string{"1"},
+	},
+	{
+		"terms are matched case sensitively",
+		"gds",
+		[]string{},
+	},
+}
+
 func TestExtract(t *testing.T) {
 	config := exampleConfig()
 	extractor := NewExtractor(config)
 	extractor.LoadEntities()
 
-	document := "This document mentions GDS but it doesn't mention the Ministry of J..."
-	matchedTermIds := extractor.Extract(document)
-	assert.Equal(t, []string{"1"}, matchedTermIds)
+	for _, example := range extractionExamples {
+		matchedTermIds := extractor.Extract(example.document)
+		assert.Equal(t, example.expectedTermIds, matchedTermIds, example.comment)
+	}
 }

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+type ParseExample struct {
+	raw   string
+	terms []string
+	id    string
+	err   error
+}
+
+var parseExamples = []ParseExample{
+	{
+		"{}",
+		[]string{},
+		"",
+		nil,
+	},
+	{
+		`{"terms":["Government digital service","GDS"],"id":"1"}`,
+		[]string{"Government digital service", "GDS"},
+		"1",
+		nil,
+	},
+	{
+		`{"`,
+		[]string{},
+		"",
+		nil,
+	},
+}
+
+func TestParseEntityFromJson(t *testing.T) {
+	for i, example := range parseExamples {
+		entity, err := EntityFromJSON(example.raw)
+
+		if err != example.err {
+			t.Error("unexpected error in example", i, "error:", err, "expected:", example.err)
+		}
+
+		joinedTerms := strings.Join(entity.terms, ",")
+		joinedExpectedTerms := strings.Join(example.terms, ",")
+		if joinedTerms != joinedExpectedTerms {
+			t.Error("in example", i, "entity.terms != example.terms", joinedTerms, joinedExpectedTerms)
+		}
+		if entity.id != example.id {
+			t.Error("in example", i, "entity.id != example.id")
+		}
+	}
+}

--- a/extractor_test.go
+++ b/extractor_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	// "strings"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -21,12 +20,12 @@ var parseExamples = []ParseExample{
 		"",
 		nil,
 	},
-	// {
-	// 	`{"terms":["Government digital service","GDS"],"id":"1"}`,
-	// 	[]string{"Government digital service", "GDS"},
-	// 	"1",
-	// 	nil,
-	// },
+	{
+		`{"terms":["Government digital service","GDS"],"id":"1"}`,
+		[]string{"Government digital service", "GDS"},
+		"1",
+		nil,
+	},
 }
 
 func TestParseEntityFromJson(t *testing.T) {
@@ -34,7 +33,7 @@ func TestParseEntityFromJson(t *testing.T) {
 		actual, err := EntityFromJSON(example.raw)
 
 		assert.Equal(t, example.expectedError, err, fmt.Sprint("unexpected error in example ", i))
-		assert.Equal(t, example.expectedTerms, actual.terms, fmt.Sprint("terms differ in example ", i))
-		assert.Equal(t, example.expectedId, actual.id, fmt.Sprint("ids differ in example ", i))
+		assert.Equal(t, example.expectedTerms, actual.Terms, fmt.Sprint("terms differ in example ", i))
+		assert.Equal(t, example.expectedId, actual.Id, fmt.Sprint("ids differ in example ", i))
 	}
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,94 @@
+package logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+type Logger interface {
+	Log(fields map[string]interface{})
+	LogFromClientRequest(fields map[string]interface{}, req *http.Request)
+}
+
+type logEntry struct {
+	Timestamp time.Time              `json:"@timestamp"`
+	Fields    map[string]interface{} `json:"@fields"`
+}
+
+type jsonLogger struct {
+	writer io.Writer
+	lines  chan *[]byte
+}
+
+// New creates a new Logger.   The output variable sets the
+// destination to which log data will be written.  This can be
+// either an io.Writer, or a string.  With the latter, this is either
+// one of "STDOUT" or "STDERR", or the path to the file to log to.
+func New(output interface{}) (logger Logger, err error) {
+	l := &jsonLogger{}
+	l.writer, err = openWriter(output)
+	if err != nil {
+		return nil, err
+	}
+	l.lines = make(chan *[]byte, 100)
+	go l.writeLoop()
+	return l, nil
+}
+
+func openWriter(output interface{}) (w io.Writer, err error) {
+	switch out := output.(type) {
+	case io.Writer:
+		w = out
+	case string:
+		if out == "STDERR" {
+			w = os.Stderr
+		} else if out == "STDOUT" {
+			w = os.Stdout
+		} else {
+			w, err = os.OpenFile(out, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+			if err != nil {
+				return nil, err
+			}
+		}
+	default:
+		return nil, fmt.Errorf("Invalid output type %T(%v)", output, output)
+	}
+	return
+}
+
+func (l *jsonLogger) writeLoop() {
+	for {
+		line := <-l.lines
+		_, err := l.writer.Write(*line)
+		if err != nil {
+			log.Printf("entity-extractor: Error writing to error log: %v", err)
+		}
+	}
+}
+
+func (l *jsonLogger) writeLine(line []byte) {
+	line = append(line, 10) // Append a newline
+	l.lines <- &line
+}
+
+func (l *jsonLogger) Log(fields map[string]interface{}) {
+	entry := &logEntry{time.Now(), fields}
+	line, err := json.Marshal(entry)
+	if err != nil {
+		log.Printf("entity-extractor/logger: Error encoding JSON: %v", err)
+	}
+	l.writeLine(line)
+}
+
+func (l *jsonLogger) LogFromClientRequest(fields map[string]interface{}, req *http.Request) {
+	fields["request_method"] = req.Method
+	fields["request"] = fmt.Sprintf("%s %s %s", req.Method, req.RequestURI, req.Proto)
+	fields["varnish_id"] = req.Header.Get("X-Varnish")
+
+	l.Log(fields)
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"github.com/alext/tablecloth"
+	"github.com/alphagov/entity-extractor/logger"
+	"log"
+	"net/http"
+	"os"
+	"runtime"
+	"sync"
+)
+
+var (
+	cfg    *Config
+	errlog logger.Logger
+)
+
+func logInfo(msg ...interface{}) {
+	log.Println(msg...)
+}
+
+func catchListenAndServe(addr string, handler http.Handler, ident string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	err := tablecloth.ListenAndServe(addr, handler, ident)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func SetGoMaxProcs() {
+	if os.Getenv("GOMAXPROCS") == "" {
+		// Use all available cores if not otherwise specified
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
+	logInfo("using GOMAXPROCS value of", runtime.GOMAXPROCS(0))
+}
+
+func SetupTablecloth() {
+	// Set working dir for tablecloth if available. This is to allow restarts to
+	// pick up new versions.
+	// See http://godoc.org/github.com/alext/tablecloth#pkg-variables for details
+	if wd := os.Getenv("GOVUK_APP_ROOT"); wd != "" {
+		tablecloth.WorkingDir = wd
+	}
+}
+
+func SetupLoggers(cfg *Config) {
+	var err error
+	errlog, err = logger.New(cfg.logPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	logInfo("logging JSON to", cfg.logPath)
+}
+
+func main() {
+	cfg = NewConfig()
+	SetupTablecloth()
+	SetupLoggers(cfg)
+	SetGoMaxProcs()
+
+	extractor := NewExtractor(cfg)
+
+	err := extractor.LoadEntities()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	extractorApi := NewExtractorAPI(extractor)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go catchListenAndServe(cfg.extractAddress, extractorApi, "extract", wg)
+	logInfo("listening for requests on", cfg.extractAddress)
+
+	wg.Wait()
+}

--- a/main.go
+++ b/main.go
@@ -4,10 +4,8 @@ import (
 	"github.com/alext/tablecloth"
 	"github.com/alphagov/entity-extractor/logger"
 	"log"
-	"net/http"
 	"os"
 	"runtime"
-	"sync"
 )
 
 var (
@@ -17,14 +15,6 @@ var (
 
 func logInfo(msg ...interface{}) {
 	log.Println(msg...)
-}
-
-func catchListenAndServe(addr string, handler http.Handler, ident string, wg *sync.WaitGroup) {
-	defer wg.Done()
-	err := tablecloth.ListenAndServe(addr, handler, ident)
-	if err != nil {
-		log.Fatal(err)
-	}
 }
 
 func SetGoMaxProcs() {
@@ -68,10 +58,9 @@ func main() {
 
 	extractorApi := NewExtractorAPI(extractor)
 
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go catchListenAndServe(cfg.extractAddress, extractorApi, "extract", wg)
 	logInfo("listening for requests on", cfg.extractAddress)
-
-	wg.Wait()
+	err = tablecloth.ListenAndServe(cfg.extractAddress, extractorApi)
+	if err != nil {
+		log.Fatal(err)
+	}
 }


### PR DESCRIPTION
## Description

This is a service with a single HTTP endpoint for extracting named entities from text
## Introduction

An entity is any well known real world _thing_ such as a person, place,
organisation, policy etc.

We'll build up a corpus of known named entities, we can use that
during document indexing and search.

The entity-extractor service will be used during both of these operations.

For a more detailed explanation please see the README.md in this PR.
## Contents of this PR

This PR implements a basic entity extractor service including
- HTTP service using [tablecloth](https://github.com/alext/tablecloth)
- matcher using [Aho-Corasick library](github.com/cloudflare/ahocorasick)
- code to read a list of entities from filesystem

This code has a few rough edges in particular:
- error handling may be missing in some places
- no test coverage of HTTP service (although there are unit tests)
## Review feedback

We intend to use this service experimentally. As mentioned above, it will be called over HTTP from rummager. Initially we'll only deploy it to preview.

Therefore, some missing error handling may be acceptable for now. At present we are trying to get an end-to-end proof of concept working.

Feedback on the following would be welcome:
- general style, organisation of the go code
- how easy it is to understand the code
- tips on how to test the HTTP service

Thanks!
