### PR TITLE
Read entities from psql

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,3 +1,4 @@
 gom 'github.com/alext/tablecloth', :commit => 'b373a9a'
 gom 'github.com/cloudflare/ahocorasick', :commit => '1ce46e42b741851faf33c1bf283eeae6676f70a8'
 gom 'github.com/stretchr/testify/assert'
+gom 'github.com/lib/pq', :commit => '19eeca3e30d2577b1761db471ec130810e67f532'

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,18 @@ build: _vendor
 run: _vendor
 	gom run $(BUILDFILES)
 
-test: _vendor
+test_database:
+	(psql -lqt | cut -d \| -f 1 | grep -q -w entity-extractor_test >/dev/null) || \
+	( \
+		(createdb -T template0 -E UTF8 entity-extractor_test) && \
+		(psql entity-extractor_test < db/schema.sql) && \
+		(psql entity-extractor_test < db/test-fixtures.sql) \
+	)
+
+drop_test_database:
+	dropdb entity-extractor_test
+
+test: _vendor test_database
 	gom test -v
 
 clean:

--- a/config.go
+++ b/config.go
@@ -7,16 +7,16 @@ import (
 )
 
 type Config struct {
-	extractAddress string
-	entitiesPath   string
-	logPath        string
+	extractAddress     string
+	dbConnectionString string
+	logPath            string
 }
 
 func NewConfig() *Config {
 	cfg := new(Config)
 
 	cfg.extractAddress = getenvDefault("EXTRACTOR_EXTRACT_ADDR", ":3096")
-	cfg.entitiesPath = getenvDefault("EXTRACTOR_ENTITIES_PATH", "data/entities.jsonl")
+	cfg.dbConnectionString = getenvDefault("EXTRACTOR_DB_CONNECTION_STRING", "host=/var/run/postgresql dbname=entity-extractor_development sslmode=disable")
 	cfg.logPath = getenvDefault("EXTRACTOR_LOG_PATH", "STDERR")
 
 	flag.Usage = usage
@@ -30,10 +30,19 @@ func usage() {
 	helpstring := `
 The following environment variables and defaults are available:
 
-EXTRACTOR_EXTRACT_ADDR=:3096  Address on which to serve extraction requests
-EXTRACTOR_ENTITIES_PATH=/var/apps/entity-extractor/data/entities.jsonl
-                              Path of file holding entities in jsonlines format
-EXTRACTOR_ERROR_LOG=STDERR    File to log errors to (in JSON format)
+EXTRACTOR_EXTRACT_ADDR
+  - Address on which to serve extraction requests
+  - Default: ':3096'
+
+EXTRACTOR_DB_CONNECTION_STRING
+  - a postgresql connection string[1] used to connect to the database.
+    Entites are read at startup from this database.
+  - Default: 'host=/var/run/postgresql dbname=entity-extractor_development sslmode=disable'
+  [1] http://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters
+
+EXTRACTOR_ERROR_LOG
+  - File to log errors to (in JSON format)
+  - Default: 'STDERR'
 `
 	fmt.Fprintf(os.Stderr, helpstring)
 	os.Exit(2)

--- a/db/test-fixtures.sql
+++ b/db/test-fixtures.sql
@@ -1,0 +1,2 @@
+INSERT INTO entities (id, terms) VALUES ('1', '["Government digital service", "GDS"]');
+INSERT INTO entities (id, terms) VALUES ('2', '["Ministry of Justice", "MoJ"]');


### PR DESCRIPTION
We've changed to read the data at startup from a postgresql database to make it easier to distribute the data across all backends.
