### PR TITLE
Read entire post body

### DIFF
--- a/extractor_api.go
+++ b/extractor_api.go
@@ -31,7 +31,7 @@ func NewExtractorAPI(extractor *Extractor) http.Handler {
 		if err != nil {
 			errlog.LogFromClientRequest(map[string]interface{}{
 				"error":  fmt.Sprintf("Error reading post body: %v", err),
-				"status": 500,
+				"status": http.StatusInternalServerError,
 			}, r)
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -41,7 +41,7 @@ func NewExtractorAPI(extractor *Extractor) http.Handler {
 		if matchedTermIds == nil {
 			errlog.LogFromClientRequest(map[string]interface{}{
 				"error":  "matchedTermIds was nil",
-				"status": 500,
+				"status": http.StatusInternalServerError,
 			}, r)
 
 			w.WriteHeader(http.StatusInternalServerError)
@@ -53,7 +53,7 @@ func NewExtractorAPI(extractor *Extractor) http.Handler {
 		if err != nil {
 			errlog.LogFromClientRequest(map[string]interface{}{
 				"error":  fmt.Sprintf("Failed to marshal matched terms to Json: %v", err),
-				"status": 500,
+				"status": http.StatusInternalServerError,
 			}, r)
 
 			w.WriteHeader(http.StatusInternalServerError)

--- a/extractor_api.go
+++ b/extractor_api.go
@@ -39,23 +39,22 @@ func NewExtractorAPI(extractor *Extractor) http.Handler {
 
 		matchedTermIds := extractor.Extract(string(postBody))
 		if matchedTermIds == nil {
-			errlog.Log(map[string]interface{}{
-				"message":  "matchedTermIds was nil",
-				"document": string(postBody),
-				"status":   500,
-			})
+			errlog.LogFromClientRequest(map[string]interface{}{
+				"error":  "matchedTermIds was nil",
+				"status": 500,
+			}, r)
 
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
-		marshalled, err := json.Marshal(matchedTermIds)
+		var marshalled []byte
+		marshalled, err = json.Marshal(matchedTermIds)
 		if err != nil {
-			errlog.Log(map[string]interface{}{
-				"message": "Failed to marshal matched terms to Json",
-				"error":   fmt.Sprintf("%v", err),
-				"status":  500,
-			})
+			errlog.LogFromClientRequest(map[string]interface{}{
+				"error":  fmt.Sprintf("Failed to marshal matched terms to Json: %v", err),
+				"status": 500,
+			}, r)
 
 			w.WriteHeader(http.StatusInternalServerError)
 			return


### PR DESCRIPTION
We were seeing intermittent errors in the client because the TCP connection was
being closed before the response body had been sent back to the client. We
suspect that this was due to the fact that sometimes the go client would not
read the entire post body for larger requests, and nginx was getting upset that
the upstream had stopped reading and therefore closed the connection before the
upstream had a chance to respond.

We have worked around this by using ioutil.ReadAll to read the entire post body.

Note that this means that the entity extractor will read an unlimited post body
size. However, in practice the amount of data that can be sent to it is limited
by nginx proxies in front.

Thanks @alext for helping to debug this!
